### PR TITLE
Chats with bots can be null

### DIFF
--- a/src/lib/api/unpack.js
+++ b/src/lib/api/unpack.js
@@ -98,7 +98,7 @@ function chats(cs) {
     favorites: cs[2].map(fave),
     dms: cs[7].map(chat),
     rooms: cs[8].map(chat),
-    bots: cs[9].map(chat),
+    bots: (cs[9] || []).map(chat),
   };
 }
 


### PR DESCRIPTION
Not having any chats with bots is 1) sad, I know, and 2) apparently represented as null instead of an empty list. This caused glycerin to throw an exception about `map` being undefined on startup.